### PR TITLE
Remove static state manager reference when cancelling a single animation

### DIFF
--- a/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/AdditiveAnimationStateManager.java
+++ b/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/AdditiveAnimationStateManager.java
@@ -90,13 +90,7 @@ class AdditiveAnimationStateManager<T> {
             return;
         }
         mAdditiveAnimationAccumulators.remove(applier);
-        if (mAdditiveAnimationAccumulators.isEmpty()) {
-            sStateManagers.remove(mAnimationTargetView);
-            // reset hardware layer
-            if(mUseHardwareLayer && mAnimationTargetView instanceof View) {
-                ((View)mAnimationTargetView).setLayerType(View.LAYER_TYPE_NONE, null);
-            }
-        }
+        removeStateManagerIfAccumulatorSetIsEmpty();
 
         for(AdditiveAnimation animation : applier.getAnimations(mAnimationTargetView)) {
             AnimationInfo info = getAnimationInfo(animation.getTag(), false);
@@ -161,8 +155,19 @@ class AdditiveAnimationStateManager<T> {
                 cancelledAppliers.add(applier);
             }
         }
+        removeStateManagerIfAccumulatorSetIsEmpty();
         mAnimationInfos.remove(propertyName);
         mAdditiveAnimationAccumulators.removeAll(cancelledAppliers);
+    }
+
+    private void removeStateManagerIfAccumulatorSetIsEmpty() {
+        if (mAdditiveAnimationAccumulators.isEmpty()) {
+            sStateManagers.remove(mAnimationTargetView);
+            // reset hardware layer
+            if(mUseHardwareLayer && mAnimationTargetView instanceof View) {
+                ((View)mAnimationTargetView).setLayerType(View.LAYER_TYPE_NONE, null);
+            }
+        }
     }
 
     Float getLastTargetValue(String propertyName) {

--- a/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/AdditiveAnimationStateManager.java
+++ b/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/AdditiveAnimationStateManager.java
@@ -155,9 +155,9 @@ class AdditiveAnimationStateManager<T> {
                 cancelledAppliers.add(applier);
             }
         }
-        removeStateManagerIfAccumulatorSetIsEmpty();
         mAnimationInfos.remove(propertyName);
         mAdditiveAnimationAccumulators.removeAll(cancelledAppliers);
+        removeStateManagerIfAccumulatorSetIsEmpty();
     }
 
     private void removeStateManagerIfAccumulatorSetIsEmpty() {


### PR DESCRIPTION
Currently, we remove static StateManager references when the animation finishes or when `cancelAllAnimations` is called. We don't, however, remove this static reference if the animation is canceled by tag, which leads to a memory leak if we cancel the only running animation in this way.

This should fix the problem by performing the same check for a finishing an animation when cancelling a single animation on a view.