### PR TITLE
#19 fix animation start/end actions not being called

### DIFF
--- a/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/animation_set/AnimationState.java
+++ b/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/animation_set/AnimationState.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public abstract class AnimationState<T extends Object> implements AnimationAction<T> {
 
-    public static class Builder<T> {
+    public static class Builder<BuilderSubclass extends Builder<?, T>, T> {
 
         @NonNull
         protected final List<Animation<T>> animations = new ArrayList<>();
@@ -23,34 +23,34 @@ public abstract class AnimationState<T extends Object> implements AnimationActio
         public Builder() {}
 
         @NonNull
-        public Builder<T> addAnimation(@NonNull AnimationAction.Animation<T> animation) {
+        public BuilderSubclass addAnimation(@NonNull AnimationAction.Animation<T> animation) {
             animations.add(animation);
-            return this;
+            return (BuilderSubclass) this;
         }
 
         @NonNull
-        public Builder<T> addAnimations(@NonNull List<AnimationAction.Animation<T>> animations) {
+        public BuilderSubclass addAnimations(@NonNull List<AnimationAction.Animation<T>> animations) {
             this.animations.addAll(animations);
-            return this;
+            return (BuilderSubclass) this;
         }
 
         @SafeVarargs
         @NonNull
-        public final Builder<T> addAnimations(@NonNull AnimationAction.Animation<T>... animations) {
+        public final BuilderSubclass addAnimations(@NonNull AnimationAction.Animation<T>... animations) {
             this.animations.addAll(Arrays.asList(animations));
-            return this;
+            return (BuilderSubclass) this;
         }
 
         @NonNull
-        public Builder<T> withEndAction(@Nullable AnimationEndAction<T> endAction) {
+        public BuilderSubclass withEndAction(@Nullable AnimationEndAction<T> endAction) {
             this.endAction = endAction;
-            return this;
+            return (BuilderSubclass) this;
         }
 
         @NonNull
-        public Builder<T> withStartAction(@Nullable AnimationStartAction<T> startAction) {
+        public BuilderSubclass withStartAction(@Nullable AnimationStartAction<T> startAction) {
             this.startAction = startAction;
-            return this;
+            return (BuilderSubclass) this;
         }
 
         public AnimationState<T> build() {

--- a/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/animation_set/view/ViewStateBuilder.java
+++ b/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/animation_set/view/ViewStateBuilder.java
@@ -1,8 +1,0 @@
-package at.wirecube.additiveanimations.additive_animator.animation_set.view;
-
-import android.view.View;
-
-import at.wirecube.additiveanimations.additive_animator.animation_set.AnimationState;
-
-public class ViewStateBuilder extends AnimationState.Builder<View> {
-}

--- a/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/view_visibility/ViewVisibilityBuilder.java
+++ b/additive_animations/src/main/java/at/wirecube/additiveanimations/additive_animator/view_visibility/ViewVisibilityBuilder.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
 
 import at.wirecube.additiveanimations.additive_animator.animation_set.AnimationState;
 
-public class ViewVisibilityBuilder extends AnimationState.Builder<View> {
+public class ViewVisibilityBuilder extends AnimationState.Builder<ViewVisibilityBuilder, View> {
 
     private final AnimationState.AnimationStartAction<View> visibilityStartAction;
     private final AnimationState.AnimationEndAction<View> visibilityEndAction;
@@ -29,32 +29,42 @@ public class ViewVisibilityBuilder extends AnimationState.Builder<View> {
             default:
                 throw new IllegalArgumentException("Cannot instantiate a ViewVisibilityAnimation.Builder without a valid visibility (given: " + visibility + ").");
         }
+        startAction = getWrappedStartAction(null);
+        endAction = getWrappedEndAction(null);
     }
 
-    @Override
-    @NonNull
-    public AnimationState.Builder<View> withStartAction(@Nullable AnimationState.AnimationStartAction<View> startAction) {
-        return super.withStartAction(view -> {
+    private AnimationState.AnimationStartAction<View> getWrappedStartAction(@Nullable AnimationState.AnimationStartAction<View> startAction) {
+        return view -> {
             if (visibilityStartAction != null) {
                 visibilityStartAction.onStart(view);
             }
             if (startAction != null) {
                 startAction.onStart(view);
             }
-        });
+        };
     }
 
-    @Override
-    @NonNull
-    public AnimationState.Builder<View> withEndAction(@Nullable AnimationState.AnimationEndAction<View> endAction) {
-        return super.withEndAction((view, wasCancelled) -> {
+    private AnimationState.AnimationEndAction<View> getWrappedEndAction(@Nullable AnimationState.AnimationEndAction<View> endAction) {
+        return (view, wasCancelled) -> {
             if (visibilityEndAction != null) {
                 visibilityEndAction.onEnd(view, wasCancelled);
             }
             if (endAction != null) {
                 endAction.onEnd(view, wasCancelled);
             }
-        });
+        };
+    }
+
+    @Override
+    @NonNull
+    public ViewVisibilityBuilder withStartAction(@Nullable AnimationState.AnimationStartAction<View> startAction) {
+        return super.withStartAction(getWrappedStartAction(startAction));
+    }
+
+    @Override
+    @NonNull
+    public ViewVisibilityBuilder withEndAction(@Nullable AnimationState.AnimationEndAction<View> endAction) {
+        return super.withEndAction(getWrappedEndAction(endAction));
     }
 
 }

--- a/demo/src/main/java/additive_animations/fragments/states/CustomViewStateAnimation.java
+++ b/demo/src/main/java/additive_animations/fragments/states/CustomViewStateAnimation.java
@@ -2,10 +2,6 @@ package additive_animations.fragments.states;
 
 import android.view.View;
 
-import androidx.annotation.Nullable;
-
-import java.util.Arrays;
-
 import at.wirecube.additiveanimations.additive_animator.animation_set.AnimationAction;
 import at.wirecube.additiveanimations.additive_animator.animation_set.AnimationState;
 import at.wirecube.additiveanimations.additive_animator.view_visibility.ViewVisibilityAnimation;
@@ -20,6 +16,10 @@ public class CustomViewStateAnimation {
                 new AnimationAction.Animation<>(View.SCALE_X, 0.1f),
                 new AnimationAction.Animation<>(View.SCALE_Y, 0.1f)
             )
+            // this shows how to attach a custom end action to any state AnimationState builder:
+//            .withEndAction((view, wasCancelled) -> {
+//                Toast.makeText(view.getContext(), "EndAction is called", Toast.LENGTH_SHORT).show();
+//            })
             .build();
     }
 
@@ -32,6 +32,10 @@ public class CustomViewStateAnimation {
                 new AnimationAction.Animation<>(View.SCALE_Y, 1f),
                 new AnimationAction.Animation<>(View.TRANSLATION_X, 0f)
             )
+            // this shows how to attach a custom start action to any state AnimationState builder:
+//            .withStartAction(view -> {
+//                Toast.makeText(view.getContext(), "StartAction is called", Toast.LENGTH_SHORT).show();
+//            })
             .build();
     }
 }

--- a/demo/src/main/java/additive_animations/fragments/states/StateDemoFragment.java
+++ b/demo/src/main/java/additive_animations/fragments/states/StateDemoFragment.java
@@ -1,21 +1,16 @@
 package additive_animations.fragments.states;
 
 import android.os.Bundle;
-
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.appcompat.widget.SwitchCompat;
-
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.fragment.app.Fragment;
+
 import at.wirecube.additiveanimations.additive_animator.AdditiveAnimator;
-import at.wirecube.additiveanimations.additive_animator.animation_set.AnimationAction;
 import at.wirecube.additiveanimations.additive_animator.animation_set.AnimationState;
-import at.wirecube.additiveanimations.additive_animator.animation_set.view.ViewAnimation;
-import at.wirecube.additiveanimations.additive_animator.animation_set.view.ViewAnimationState;
-import at.wirecube.additiveanimations.additive_animator.animation_set.view.ViewStateBuilder;
 import at.wirecube.additiveanimations.additive_animator.view_visibility.ViewVisibilityAnimation;
 import at.wirecube.additiveanimations.additiveanimationsdemo.R;
 

--- a/demo/src/main/res/layout/fragment_state_demo.xml
+++ b/demo/src/main/res/layout/fragment_state_demo.xml
@@ -22,7 +22,7 @@
         android:layout_height="100dp"
         android:layout_marginLeft="50dp"
         android:layout_marginTop="50dp"
-        android:background="@color/niceOrange"></View>
+        android:background="@color/niceOrange" />
 
     <View
         android:id="@+id/animated_view2"
@@ -30,7 +30,7 @@
         android:layout_height="100dp"
         android:layout_marginLeft="156dp"
         android:layout_marginTop="50dp"
-        android:background="@color/nicePink"></View>
+        android:background="@color/nicePink" />
 
     <View
         android:id="@+id/animated_view3"
@@ -38,6 +38,6 @@
         android:layout_height="100dp"
         android:layout_marginLeft="50dp"
         android:layout_marginTop="166dp"
-        android:background="@color/niceBlue"></View>
+        android:background="@color/niceBlue" />
 
 </RelativeLayout>


### PR DESCRIPTION
The start/end actions for the default view visibility animations (created by the `ViewVisibilityBuilder`) were not called if you didn't call `withStartAction()` or `withEndAction()` on the builder afterwards.
This PR also fixes an issue where the start/end actions might be called multiple times for the same view when animating multiple properties in the same state animation.